### PR TITLE
Install target additon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ script:
   - qmake mystiq.pro
   - make
   - sudo make install
-  
 
 # notifications (only via telegram)
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ install:
 script:
   - qmake mystiq.pro
   - make
+  - sudo make install
+  
 
 # notifications (only via telegram)
 notifications:

--- a/INSTALL
+++ b/INSTALL
@@ -17,12 +17,21 @@ optdepends=('sox: audio speed adjusting support'
 To build and run, on Ubuntu and derivated install:
 sudo apt install ffmpeg sox mplayer libnotify-dev qt5-default qt5-qmake g++ make
 
+Warning! you need Ubuntu 19.04 or greater is you are using bionic 18.04 then you
+need a most up to date QT, as this project needs QT5.10.1 or greater, google is
+your friend about how to upgrade the Qt version, hint: "install qt5.12 ppa bionic"
+
 Compile:
   - clone git repository: "git clone https://github.com/llamaret/mystiq.git"
   - run "qmake <option>"
   - run "make"
-  - run ./mystiq
-  
+
+Test it locally:
+  - run "./mystiq"
+
+Install (system wide for all users):
+  - run "sudo make install"
+
 qmake options:
 DEFINES+=NO_NEW_VERSION_CHECK
   

--- a/mystiq.pro
+++ b/mystiq.pro
@@ -153,9 +153,10 @@ unix {
     SOURCES -= services/powermanagement-dummy.cpp
     SOURCES += services/powermanagement-linux.cpp
     # Install
-    target.path = /usr/local/bin
-    desktop.path = /usr/local/share/applications
+    target.path = /usr/local/bin/
+    desktop.path = /usr/local/share/applications/
     desktop.files += mystiq.desktop
+    desktop.uninstall += rm /usr/share/icons/mystiq.png
     desktop.extra += cd icons && cp mystiq_96x96.png /usr/share/icons/mystiq.png
     INSTALLS += target desktop
 

--- a/mystiq.pro
+++ b/mystiq.pro
@@ -152,6 +152,13 @@ unix {
     QT += dbus
     SOURCES -= services/powermanagement-dummy.cpp
     SOURCES += services/powermanagement-linux.cpp
+    # Install
+    target.path = /usr/local/bin
+    desktop.path = /usr/local/share/applications
+    desktop.files += mystiq.desktop
+    desktop.extra += cd icons && cp mystiq_96x96.png /usr/share/icons/mystiq.png
+    INSTALLS += target desktop
+
 }
 
 win32 {


### PR DESCRIPTION
This has the settings to add a `make install` target, remember it need sudo before or it will not work.
