### PR TITLE
Deb/AppImage deploy on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ script:
   - qmake mystiq.pro
   - make
   - sudo make install
-  
 
 # notifications (only via telegram)
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,11 @@ matrix:
 install:
   - sudo add-apt-repository -y ppa:beineri/opt-qt-5.12.3-xenial
   - sudo apt update
-  - sudo apt install build-essential g++ make ffmpeg sox mplayer libnotify-dev mesa-common-dev
+  - sudo apt install build-essential g++ make ffmpeg sox mplayer libnotify-dev mesa-common-dev tree
   - sudo apt install qt-latest
   - echo "/opt/qt510/bin" | sudo tee /etc/xdg/qtchooser/default.conf
   - echo "/opt/qt510/lib" | sudo tee -a /etc/xdg/qtchooser/default.conf
+  - tree /opt/
   - qtchooser -print-env
   - qmake -v
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ install:
 script:
   - qmake mystiq.pro
   - make
+  - sudo make install
+  
 
 # notifications (only via telegram)
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ install:
   - sudo add-apt-repository -y ppa:beineri/opt-qt-5.12.3-xenial
   - sudo apt update
   - sudo apt install build-essential g++ make ffmpeg sox mplayer libnotify-dev mesa-common-dev tree
-  - sudo apt install qt-latest
-  - echo "/opt/qt510/bin" | sudo tee /etc/xdg/qtchooser/default.conf
-  - echo "/opt/qt510/lib" | sudo tee -a /etc/xdg/qtchooser/default.conf
-  - tree /opt/
+  - sudo apt install qt512-meta-full
+  #- echo "/opt/qt510/bin" | sudo tee /etc/xdg/qtchooser/default.conf
+  #- echo "/opt/qt510/lib" | sudo tee -a /etc/xdg/qtchooser/default.conf
+  #- tree /opt/
   - qtchooser -print-env
   - qmake -v
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,20 @@ compiler: gcc
 # main build matrix
 matrix:
   include:
-    - name: "Bionic Ubuntu Linux"
+    - name: "Ubuntu Linux"
       os: linux
-      dist: bionic
+      dist: trusty
       sudo: required
-      env: TARGETOS=bionic-linux
+      env: TARGETOS=linux
 
 # install, install QT5.12.3 from ppa
 install:
-  - sudo add-apt-repository -y ppa:beineri/opt-qt-5.12.3-bionic
+  - sudo add-apt-repository -y ppa:beineri/opt-qt-5.10.1-trusty
   - sudo apt update
   - sudo apt install build-essential g++ make ffmpeg sox mplayer libnotify-dev mesa-common-dev libglvnd-dev
   - sudo apt install qt-latest
-  - echo "/opt/qt512/bin" | sudo tee /etc/xdg/qtchooser/default.conf
-  - echo "/opt/qt512/lib" | sudo tee -a /etc/xdg/qtchooser/default.conf
+  - echo "/opt/qt510/bin" | sudo tee /etc/xdg/qtchooser/default.conf
+  - echo "/opt/qt510/lib" | sudo tee -a /etc/xdg/qtchooser/default.conf
   - qtchooser -print-env
   - qmake -v
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ matrix:
   include:
     - name: "Ubuntu Linux"
       os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       env: TARGETOS=linux
 
 # install, install QT5.12.3 from ppa
 install:
-  - sudo add-apt-repository -y ppa:beineri/opt-qt-5.10.1-trusty
+  - sudo add-apt-repository -y ppa:beineri/opt-qt-5.12.3-xenial
   - sudo apt update
   - sudo apt install build-essential g++ make ffmpeg sox mplayer libnotify-dev mesa-common-dev libglvnd-dev
   - sudo apt install qt-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
 install:
   - sudo add-apt-repository -y ppa:beineri/opt-qt-5.12.3-xenial
   - sudo apt update
-  - sudo apt install build-essential g++ make ffmpeg sox mplayer libnotify-dev mesa-common-dev libglvnd-dev
+  - sudo apt install build-essential g++ make ffmpeg sox mplayer libnotify-dev mesa-common-dev
   - sudo apt install qt-latest
   - echo "/opt/qt510/bin" | sudo tee /etc/xdg/qtchooser/default.conf
   - echo "/opt/qt510/lib" | sudo tee -a /etc/xdg/qtchooser/default.conf

--- a/INSTALL
+++ b/INSTALL
@@ -17,12 +17,21 @@ optdepends=('sox: audio speed adjusting support'
 To build and run, on Ubuntu and derivated install:
 sudo apt install ffmpeg sox mplayer libnotify-dev qt5-default qt5-qmake g++ make
 
+Warning! you need Ubuntu 19.04 or greater is you are using bionic 18.04 then you
+need a most up to date QT, as this project needs QT5.10.1 or greater, google is
+your friend about how to upgrade the Qt version, hint: "install qt5.12 ppa bionic"
+
 Compile:
   - clone git repository: "git clone https://github.com/llamaret/mystiq.git"
   - run "qmake <option>"
   - run "make"
-  - run ./mystiq
-  
+
+Test it locally:
+  - run "./mystiq"
+
+Install (system wide for all users):
+  - run "sudo make install"
+
 qmake options:
 DEFINES+=NO_NEW_VERSION_CHECK
   

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 MystiQ, FFmpeg GUI front-end based on Qt5
 =========================================
 
+[![Build Status](https://travis-ci.org/llamaret/MystiQ.svg?branch=develop)](https://travis-ci.org/llamaret/MystiQ)
+
 Introduction
 ------------
 

--- a/mystiq.pro
+++ b/mystiq.pro
@@ -153,9 +153,10 @@ unix {
     SOURCES -= services/powermanagement-dummy.cpp
     SOURCES += services/powermanagement-linux.cpp
     # Install
-    target.path = /usr/local/bin
-    desktop.path = /usr/local/share/applications
+    target.path = /usr/local/bin/
+    desktop.path = /usr/local/share/applications/
     desktop.files += mystiq.desktop
+    desktop.uninstall += rm /usr/share/icons/mystiq.png
     desktop.extra += cd icons && cp mystiq_96x96.png /usr/share/icons/mystiq.png
     INSTALLS += target desktop
 

--- a/mystiq.pro
+++ b/mystiq.pro
@@ -152,6 +152,13 @@ unix {
     QT += dbus
     SOURCES -= services/powermanagement-dummy.cpp
     SOURCES += services/powermanagement-linux.cpp
+    # Install
+    target.path = /usr/local/bin
+    desktop.path = /usr/local/share/applications
+    desktop.files += mystiq.desktop
+    desktop.extra += cd icons && cp mystiq_96x96.png /usr/share/icons/mystiq.png
+    INSTALLS += target desktop
+
 }
 
 win32 {


### PR DESCRIPTION
We will explore the ways to release an AppImage that can be usable on all linuxes instead of a .deb file

For that we will use linuxdeployqt from here https://github.com/probonopd/linuxdeployqt
